### PR TITLE
chore: bump to use go1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
         cache: true
 
     - name: Cache Go modules

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ This guide covers setting up the development environment for Moribito.
 
 ## Prerequisites
 
-- Go 1.24.6 or later
+- Go 1.25.1 or later
 - Git
 - Make (for build automation)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ericschmar/moribito
 
-go 1.24.6
+go 1.25.1
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
update to use go 1.25 