### PR TITLE
Add copy command to Record view help bar

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -644,7 +644,7 @@ func (m *Model) renderHelpBar() string {
 			helpText = "Tree view requires LDAP connection"
 		}
 	case ViewModeRecord:
-		helpText = "View LDAP record details • [↑↓] navigate attributes"
+		helpText = "View LDAP record details • [↑↓] navigate attributes • [C] copy value"
 	}
 
 	style := lipgloss.NewStyle().


### PR DESCRIPTION
## Summary
Updates the Record view help bar to include documentation about the copy functionality. Users can press `C` to copy the current attribute value, but this wasn't documented in the help bar.

## Changes
- Updated help bar text in `internal/tui/model.go` to show `[C] copy value` command
- Changed from: "View LDAP record details • [↑↓] navigate attributes"
- Changed to: "View LDAP record details • [↑↓] navigate attributes • [C] copy value"

## Test Plan
- [x] Built the application successfully with `go build`
- [x] Verified existing tests still pass (pre-existing test failures unrelated to this change)
- [x] Confirmed change only affects help bar text display

## Screenshots
N/A - Text-only change to help bar

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)